### PR TITLE
Added a bit about how to reset factory defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Change foreground, background or cursor color: ```term_.prefs_.set('foreground-c
 
 Blinking cursor? ```term_.prefs_.set('cursor-blink', false)```
 
+Screwed something up?  Globally undo everything you changed: ```term_.prefs_.resetAll()```
+
 
 ## Related useful stuff
 


### PR DESCRIPTION
I was tweaking my terminal preferences and accidentally screwed up the highlighting colors.  I still haven't found how to modify the highlight color itself, but at least there's a `reset` available.  Edited the readme to include the `resetAll()` command.
